### PR TITLE
Update robinhood_crypto_api.py

### DIFF
--- a/robinhood_crypto_api/robinhood_crypto_api.py
+++ b/robinhood_crypto_api/robinhood_crypto_api.py
@@ -58,6 +58,11 @@ class RobinhoodCrypto:
     PAIRS = {
         'BTCUSD': '3d961844-d360-45fc-989b-f6fca761d511',
         'ETHUSD': '76637d50-c702-4ed1-bcb5-5b0732a81f48',
+        'ETCUSD': '7b577ce3-489d-4269-9408-796a0d1abb3a',
+        'BCHUSD': '2f2b77c4-e426-4271-ae49-18d5cb296d3a',
+        'BSVUSD': '086a8f9f-6c39-43fa-ac9f-57952f4a1ba6',
+        'LTCUSD': '383280b1-ff53-43fc-9c84-f01afd0989cd',
+        'DOGEUSD': '1ef78e1b-049b-4f12-90e5-555dcf2fe204'
     }
 
     ENDPOINTS = {


### PR DESCRIPTION
add ETC-USD, BCH-USD, BSV-USD, LTC-USD, and DOGE-USD currency pairs